### PR TITLE
chore:ENG-17655 Pin GitHub Actions refs to SHA

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,9 +13,9 @@ jobs:
     env:
       WORKING_DIRECTORY: ./
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Node.js
-        uses: actions/setup-node@v4.1.0
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 20.19.4
           cache: "yarn"
@@ -32,9 +32,9 @@ jobs:
     env:
       WORKING_DIRECTORY: ./
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Node.js
-        uses: actions/setup-node@v4.1.0
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 20.19.4
           cache: "yarn"


### PR DESCRIPTION
## Description
Pins 4 unpinned GitHub Actions refs in `react-diff-viewer` `.github/workflows/build-test.yml` for [ENG-17655](https://app.clickup.com/t/45000662/ENG-17655) org Actions SHA-pin audit remediation:

1. `actions/checkout@v4.2.2` → `@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2` (2 occurrences)
2. `actions/setup-node@v4.1.0` → `@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0` (2 occurrences)

## Checklist
<!-- Please place an "x" between brackets to mark each relevant box -->

<!-- This Pull Request ... -->
- [x] Links to Clickup
- [x] Follows PR title convention (`<label>:ENG-XXXX <description>`)
- [ ] Introduces new tests on the code paths changed
- [ ] Has been manually verified
- [ ] Generates no new console or log warnings/errors (manual check)
- [ ] Documentation added/updated as applicable

## Testing Description
N/A for runtime — changes are GitHub Actions `uses:` pin-only. Verified pins match current tips of the original tags (`v4.2.2`, `v4.1.0`). No workflow execute/verify run was performed.

### Before

N/A

### After

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned workflow action versions to specific revisions, improving build and test process reliability.
  * No changes to application functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->