### PR TITLE
Fix failing release publish action

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-          cache-dependency-path: '${{ env.WORKING_DIRECTORY }}/yarn.lock'
+          node-version-file: ".nvmrc"
+          cache: "yarn"
+          cache-dependency-path: "${{ env.WORKING_DIRECTORY }}/yarn.lock"
 
       - name: Install dependencies
         run: yarn install
@@ -40,9 +40,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-          cache-dependency-path: '${{ env.WORKING_DIRECTORY }}/yarn.lock'
+          node-version-file: ".nvmrc"
+          cache: "yarn"
+          cache-dependency-path: "${{ env.WORKING_DIRECTORY }}/yarn.lock"
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -48,9 +48,9 @@ jobs:
       - name: Configure registry auth
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@copia-automation'
+          node-version-file: ".nvmrc"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@copia-automation"
 
       - name: Publish
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,8 +30,6 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@copia-automation'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -44,6 +42,15 @@ jobs:
 
       - name: Test
         run: yarn test
+
+      # Registry auth is configured here, not in the setup-node step above
+      # Dummy NODE_AUTH_TOKEN was removed in v7 and can cause failures in yarn/npm if not set (we only set in Publish step below)
+      - name: Configure registry auth
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@copia-automation'
 
       - name: Publish
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copia-automation/react-diff-viewer",
-  "version": "4.0.8-beta.0",
+  "version": "4.0.7",
   "private": false,
   "description": "A simple and beautiful text diff viewer component made with diff and React",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copia-automation/react-diff-viewer",
-  "version": "4.0.7",
+  "version": "4.0.8-beta.0",
   "private": false,
   "description": "A simple and beautiful text diff viewer component made with diff and React",
   "keywords": [


### PR DESCRIPTION
actions/setup-node v7 breaking change:
```
The dummy NODE_AUTH_TOKEN fallback has been removed, as it could unintentionally affect the generated .npmrc with a non-functional token. With this change, if registry-url is set without NODE_AUTH_TOKEN, legacy Yarn Classic (1.x) and older Node/npm versions may fail, and pnpm may warn. npm Trusted Publishing (OIDC) is not affected, since it does not use NODE_AUTH_TOKEN.
```

Fixed by adding 2nd setup-node step with registry/scope fields right before publishing (where we set `NODE_AUTH_TOKEN`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved package publishing setup to apply registry authentication at the appropriate stage.
  * Updated build and test automation configuration without changing its behavior.
  * Updated the package version to `4.0.8-beta.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->